### PR TITLE
link to snapcraft.io from the logo

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -68,7 +68,7 @@
       <div class="row">
         <div class="p-navigation__banner">
           <div class="p-navigation__logo">
-            <a class="p-navigation__link" href="/">
+            <a class="p-navigation__link" href="https://snapcraft.io/">
               <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft">
             </a>
           </div>


### PR DESCRIPTION
QA
--

`./run`, run the site, click the logo, end up on https://snapcraft.io (like the current https://docs.snapcraft.io site)